### PR TITLE
Mini-interpreter

### DIFF
--- a/Compiler/Visitors/CodeGen.cs
+++ b/Compiler/Visitors/CodeGen.cs
@@ -669,8 +669,10 @@ public class CodeGen : DepthFirstAdapter, IDisposable
     public override void CaseAUnaryminusExp(AUnaryminusExp node)
     {
         node.GetExp();
-        if (node.Parent() is not ATypedGlobal or AUntypedGlobal)
-            writer.Write("-" + node.GetExp().ToString().Trim());
+        if (node.Parent() is not (not ATypedGlobal or AUntypedGlobal)) 
+            return;
+        writer.Write("-");
+        node.GetExp().Apply(this);
     }
 
     public override void CaseAOrExp(AOrExp node)
@@ -720,32 +722,39 @@ public class CodeGen : DepthFirstAdapter, IDisposable
 
     public override void CaseASuffixplusplusExp(ASuffixplusplusExp node)
     {
-        Indent("++" + node.GetExp().ToString().Trim());
+        node.GetExp().Apply(this);
+        writer.Write("++");
     }
 
     public override void CaseAPrefixplusplusExp(APrefixplusplusExp node)
     {
-        Indent(node.GetExp().ToString().Trim() + "++");
+        writer.Write("++");
+        node.GetExp().Apply(this);
     }
 
     public override void CaseASuffixminusminusExp(ASuffixminusminusExp node)
     {
-        Indent(node.GetExp().ToString().Trim() + "--");
+        node.GetExp().Apply(this);
+        writer.Write("--");
     }
 
     public override void CaseAPrefixminusminusExp(APrefixminusminusExp node)
     {
-        Indent("--" + node.GetExp().ToString().Trim());
+        writer.Write("--");
+        node.GetExp().Apply(this);
     }
 
     public override void CaseALogicalnotExp(ALogicalnotExp node)
     {
-        writer.Write($"!{node.GetExp()}");
+        writer.Write("!");
+        node.GetExp().Apply(this);
     }
 
     public override void CaseAReadpinExp(AReadpinExp node)
     {
-        writer.Write($"digitalRead({node.GetExp().ToString().Trim()})");
+        writer.Write("digitalRead(");
+        node.GetExp().Apply(this);
+        writer.Write(")");
     }
 
     public override void CaseACastExp(ACastExp node)
@@ -811,14 +820,15 @@ public class CodeGen : DepthFirstAdapter, IDisposable
         writer.Write("value");
     }
 
-    public override void CaseABooleanExp(ABooleanExp node)
+    public override void CaseATrueBoolean(ATrueBoolean node)
     {
-        if (node.GetBoolean() is ATrueBoolean)
-            writer.Write("true");
-        else if (node.GetBoolean() is AFalseBoolean)
-            writer.Write("false");
+        writer.Write("true");
     }
 
+    public override void CaseAFalseBoolean(AFalseBoolean node)
+    {
+        writer.Write("false");
+    }
     public override void CaseAStringExp(AStringExp node)
     {
         writer.Write("String(" + node.GetString().ToString().Trim() + ")");
@@ -910,6 +920,8 @@ public class CodeGen : DepthFirstAdapter, IDisposable
         node.GetExp().Apply(this);
         writer.Write(")");
     }
+
+    
 
     public void Dispose()
     {

--- a/Compiler/Visitors/CodeGen.cs
+++ b/Compiler/Visitors/CodeGen.cs
@@ -843,14 +843,38 @@ public class CodeGen : DepthFirstAdapter, IDisposable
     public override void CaseAUnitdecimalExp(AUnitdecimalExp node)
     {
         AUnitdeclGlobal? test = symbolTable.GetUnitdeclFromId(node.GetId().ToString().Trim());
-        writer.Write(test.GetId().ToString().Trim() + node.GetId().ToString().Trim()
-                                                    + "(" + node.GetDecimal().ToString().Trim() + ")");    
+
+        ExprEvaluator exprEvaluator = new(node.GetDecimal());
+        PExp exp = symbolTable.GetSubUnitExp(node.GetId());
+        try
+        {
+            exp.Apply(exprEvaluator);
+        }
+        catch (NullReferenceException e)
+        {
+            writer.Write(test.GetId().ToString().Trim() + node.GetId().ToString().Trim()
+                                                        + "(" + node.GetDecimal().ToString().Trim() + ")");
+            return;
+        }
+        writer.Write(exprEvaluator.GetOutput(exp));
     }
     public override void CaseAUnitnumberExp(AUnitnumberExp node)
     {
         AUnitdeclGlobal? test = symbolTable.GetUnitdeclFromId(node.GetId().ToString().Trim());
-        writer.Write(test.GetId().ToString().Trim() + node.GetId().ToString().Trim()
-                                                    + "(" + node.GetNumber().ToString().Trim() + ")");
+        
+        ExprEvaluator exprEvaluator = new(node.GetNumber());
+        PExp exp = symbolTable.GetSubUnitExp(node.GetId());
+        try
+        {
+            exp.Apply(exprEvaluator);
+        }
+        catch (NullReferenceException e)
+        {
+            writer.Write(test.GetId().ToString().Trim() + node.GetId().ToString().Trim()
+                                                        + "(" + node.GetNumber().ToString().Trim() + ")");
+            return;
+        }
+        writer.Write(exprEvaluator.GetOutput(exp));
     }
     public void Dispose()
     {

--- a/Compiler/Visitors/CodeGen.cs
+++ b/Compiler/Visitors/CodeGen.cs
@@ -904,7 +904,7 @@ public class CodeGen : DepthFirstAdapter, IDisposable
         writer.WriteLine(";");
     }
 
-    public override void CaseAExpExp(AExpExp node)
+    public override void CaseAParenthesisExp(AParenthesisExp node)
     {
         writer.Write("(");
         node.GetExp().Apply(this);

--- a/Compiler/Visitors/ExprEvaluator.cs
+++ b/Compiler/Visitors/ExprEvaluator.cs
@@ -31,7 +31,8 @@ public class ExprEvaluator : DepthFirstAdapter
     {
         values.Add(node, int.Parse(node.GetNumber().Text));
     }
-    public override void OutAExpExp(AExpExp node)
+
+    public override void OutAParenthesisExp(AParenthesisExp node)
     {
         values.Add(node, values[node.GetExp()]);
     }

--- a/Compiler/Visitors/ExprEvaluator.cs
+++ b/Compiler/Visitors/ExprEvaluator.cs
@@ -1,0 +1,100 @@
+﻿using System.Globalization;
+using Moduino.analysis;
+using Moduino.node;
+
+namespace Compiler.Visitors;
+
+public class ExprEvaluator : DepthFirstAdapter
+{
+    private Dictionary<Node, float> values = new();
+    private float value;
+
+    public ExprEvaluator(TDecimal value)
+    {
+        this.value = float.Parse(value.Text, CultureInfo.InvariantCulture);
+    }
+
+    public ExprEvaluator(TNumber value)
+    {
+        this.value = int.Parse(value.Text);
+    }
+    
+    public string GetOutput(Node node)
+    {
+        return values[node].ToString(CultureInfo.InvariantCulture);
+    }
+
+    public override void OutANumberExp(ANumberExp node)
+    {
+        values.Add(node, int.Parse(node.GetNumber().Text));
+    }
+    public override void OutAExpExp(AExpExp node)
+    {
+        values.Add(node, values[node.GetExp()]);
+    }
+    
+    public override void OutAPlusExp(APlusExp node)
+    {
+        values.Add(node, values[node.GetL()] + values[node.GetR()]);
+    }
+
+    public override void OutADecimalExp(ADecimalExp node)
+    {
+        values.Add(node, float.Parse(node.GetDecimal().ToString(), NumberStyles.Float));
+    }
+
+    public override void OutAMinusExp(AMinusExp node)
+    {
+        values.Add(node, values[node.GetL()] - values[node.GetR()]);
+    }
+
+    public override void OutAMultiplyExp(AMultiplyExp node)
+    {
+        values.Add(node, values[node.GetL()] * values[node.GetR()]);
+    }
+
+    public override void OutAPrefixminusminusExp(APrefixminusminusExp node)
+    {
+        values.Add(node, --values[node.GetExp()]);
+    }
+
+    public override void OutADivideExp(ADivideExp node)
+    {
+        values.Add(node, values[node.GetL()] / values[node.GetR()]);
+    }
+
+    public override void OutAPrefixplusplusExp(APrefixplusplusExp node)
+    {
+        values.Add(node, ++values[node.GetExp()]);
+    }
+
+    public override void OutAValueExp(AValueExp node)
+    {
+        values.Add(node, value);
+    }
+
+    public override void OutASuffixplusplusExp(ASuffixplusplusExp node)
+    {
+        values.Add(node, values[node.GetExp()]++);
+    }
+
+    public override void OutAUnaryminusExp(AUnaryminusExp node)
+    {
+        values.Add(node, -values[node.GetExp()]);
+    }
+
+    public override void OutASuffixminusminusExp(ASuffixminusminusExp node)
+    {
+        values.Add(node, values[node.GetExp()]--);
+    }
+
+    public override void OutARemainderExp(ARemainderExp node)
+    {
+        values.Add(node, values[node.GetL()] % values[node.GetR()]);
+    }
+
+    public override void OutACastExp(ACastExp node)
+    {
+        values.Add(node, values[node.GetExp()]);
+    }
+}

--- a/Compiler/Visitors/ExprEvaluator.cs
+++ b/Compiler/Visitors/ExprEvaluator.cs
@@ -6,22 +6,25 @@ namespace Compiler.Visitors;
 
 public class ExprEvaluator : DepthFirstAdapter
 {
-    private Dictionary<Node, float> values = new();
+    private Dictionary<Node, object> values = new();
     private float value;
+    private Node startNode;
 
-    public ExprEvaluator(TDecimal value)
+    public ExprEvaluator(AUnitdecimalExp node, Node startNode)
     {
-        this.value = float.Parse(value.Text, CultureInfo.InvariantCulture);
+        value = float.Parse(node.GetDecimal().Text, CultureInfo.InvariantCulture);
+        this.startNode = startNode;
     }
 
-    public ExprEvaluator(TNumber value)
+    public ExprEvaluator(AUnitnumberExp node, Node startNode)
     {
-        this.value = int.Parse(value.Text);
+        value = int.Parse(node.GetNumber().Text);
+        this.startNode = startNode;
     }
     
-    public string GetOutput(Node node)
+    public string GetOutput()
     {
-        return values[node].ToString(CultureInfo.InvariantCulture);
+        return ((float) values[startNode]).ToString(CultureInfo.InvariantCulture);
     }
 
     public override void OutANumberExp(ANumberExp node)
@@ -35,37 +38,66 @@ public class ExprEvaluator : DepthFirstAdapter
     
     public override void OutAPlusExp(APlusExp node)
     {
-        values.Add(node, values[node.GetL()] + values[node.GetR()]);
+        values.Add(node, (values[node.GetL()], values[node.GetR()]) switch
+        {
+            // float, int, string
+            (float a, float b) => a + b,
+            (int a, int b) => a + b,
+            (string a, string b) => a + b,
+            //float, int
+            (float a, int b) => a + b,
+            (int a, float b) => a + b,
+            //int, string
+            (string a, int b) => a + b,
+            (int a, string b) => a + b,
+            //float, string
+            (string a, float b) => a + b,
+            (float a, string b) => a + b,
+        });
     }
 
     public override void OutADecimalExp(ADecimalExp node)
     {
-        values.Add(node, float.Parse(node.GetDecimal().ToString(), NumberStyles.Float));
+        values.Add(node, float.Parse(node.GetDecimal().ToString()));
     }
 
     public override void OutAMinusExp(AMinusExp node)
     {
-        values.Add(node, values[node.GetL()] - values[node.GetR()]);
+        values.Add(node, (values[node.GetL()], values[node.GetR()]) switch
+        {
+            // float, int
+            (float a, float b) => a - b,
+            (int a, int b) => a - b,
+            
+            (float a, int b) => a - b,
+            (int a, float b) => a - b,
+        });
     }
 
     public override void OutAMultiplyExp(AMultiplyExp node)
     {
-        values.Add(node, values[node.GetL()] * values[node.GetR()]);
-    }
-
-    public override void OutAPrefixminusminusExp(APrefixminusminusExp node)
-    {
-        values.Add(node, --values[node.GetExp()]);
+        values.Add(node, (values[node.GetL()], values[node.GetR()]) switch
+        {
+            // float, int
+            (float a, float b) => a * b,
+            (int a, int b) => a * b,
+            
+            (float a, int b) => a * b,
+            (int a, float b) => a * b,
+        });
     }
 
     public override void OutADivideExp(ADivideExp node)
     {
-        values.Add(node, values[node.GetL()] / values[node.GetR()]);
-    }
-
-    public override void OutAPrefixplusplusExp(APrefixplusplusExp node)
-    {
-        values.Add(node, ++values[node.GetExp()]);
+        values.Add(node, (values[node.GetL()], values[node.GetR()]) switch
+        {
+            // float, int
+            (float a, float b) => a / b,
+            (int a, int b) => a / b,
+            
+            (float a, int b) => a / b,
+            (int a, float b) => a / b,
+        });
     }
 
     public override void OutAValueExp(AValueExp node)
@@ -73,28 +105,196 @@ public class ExprEvaluator : DepthFirstAdapter
         values.Add(node, value);
     }
 
-    public override void OutASuffixplusplusExp(ASuffixplusplusExp node)
-    {
-        values.Add(node, values[node.GetExp()]++);
-    }
-
     public override void OutAUnaryminusExp(AUnaryminusExp node)
     {
-        values.Add(node, -values[node.GetExp()]);
-    }
-
-    public override void OutASuffixminusminusExp(ASuffixminusminusExp node)
-    {
-        values.Add(node, values[node.GetExp()]--);
+        values.Add(node, values[node.GetExp()] switch
+        {
+            int a => -a,
+            float a => -a,
+            });
     }
 
     public override void OutARemainderExp(ARemainderExp node)
     {
-        values.Add(node, values[node.GetL()] % values[node.GetR()]);
+        values.Add(node, (int)values[node.GetL()] % (int)values[node.GetR()]);
     }
 
     public override void OutACastExp(ACastExp node)
     {
+        values.Add(node, (node.GetType(), values[node.GetExp()]) switch
+        {
+            (AIntType, int a) => a,
+            (ADecimalType, float a) => a,
+            (ABoolType, bool a) => a, 
+            (ACharType, char a) => a, //TODO: Char everywhere else
+            (AStringType, string a) => a,
+            (ADecimalType, int a) => (float) a,
+            (AIntType, decimal a) => (float) a,
+            (AStringType, char a) => "" + a,
+            (AStringType, int a) => a.ToString(),
+            (AStringType, float a) => a.ToString(CultureInfo.InvariantCulture),
+            (ACharType, int a) => (char) a,
+        });
         values.Add(node, values[node.GetExp()]);
+    }
+
+    public override void OutABooleanExp(ABooleanExp node)
+    {
+        values.Add(node, values[node.GetBoolean()]);
+    }
+
+    public override void OutATrueBoolean(ATrueBoolean node)
+    {
+        values.Add(node, true);
+    }
+
+    public override void OutAFalseBoolean(AFalseBoolean node)
+    {
+        values.Add(node, false);
+    }
+
+    public override void CaseATernaryExp(ATernaryExp node)
+    {
+        node.GetCond().Apply(this);
+        if ((bool)values[node.GetCond()])
+        {
+            node.GetTrue().Apply(this);
+            values.Add(node, values[node.GetTrue()]);
+        }
+        else
+        {
+            node.GetFalse().Apply(this);
+            values.Add(node, values[node.GetFalse()]);
+        }
+    }
+
+    public override void CaseAAndExp(AAndExp node)
+    {
+        node.GetL().Apply(this);
+        if ((bool)values[node.GetL()])
+        {
+            node.GetR().Apply(this);
+            values.Add(node, values[node.GetR()]);
+            return;
+        }
+        values.Add(node, false);
+    }
+
+    public override void CaseAOrExp(AOrExp node)
+    {
+        node.GetL().Apply(this);
+        if (!(bool)values[node.GetL()])
+        {
+            node.GetR().Apply(this);
+            values.Add(node, values[node.GetR()]);
+            return;
+        }
+        values.Add(node, true);
+    }
+
+    public override void OutAStringExp(AStringExp node)
+    {
+        values.Add(node, node.GetString().Text);
+    }
+
+    public override void OutAEqualExp(AEqualExp node)
+    {
+        values.Add(node,  (values[node.GetL()], values[node.GetR()]) switch
+        {
+            // float, int, string
+            (float a, float b) => Math.Abs(a - b) < 0.05f,
+            (int a, int b) => a == b,
+            (string a, string b) => a == b,
+            //float, int
+            (float a, int b) => Math.Abs(a - b) < 0.05f,
+            (int a, float b) => Math.Abs(a - b) < 0.05f,
+            //int, string
+            (string a, int b) => a == b.ToString(),
+            (int a, string b) => a.ToString() == b,
+            //float, string
+            (string a, float b) => a == b.ToString(CultureInfo.InvariantCulture),
+            (float a, string b) => a.ToString(CultureInfo.InvariantCulture) == b,
+            //bool
+            (bool a, bool b) => a == b
+        });
+    }
+
+    public override void OutALessequalExp(ALessequalExp node)
+    {
+        values.Add(node, (values[node.GetL()], values[node.GetR()]) switch
+        {
+            // float, int
+            (float a, float b) => a <= b,
+            (int a, int b) => a <= b,
+            //float, int
+            (float a, int b) => a <= b,
+            (int a, float b) => a <= b,
+        });
+    }
+
+    public override void OutALessExp(ALessExp node)
+    {
+        values.Add(node, (values[node.GetL()], values[node.GetR()]) switch
+        {
+            // float, int
+            (float a, float b) => a < b,
+            (int a, int b) => a < b,
+            //float, int
+            (float a, int b) => a < b,
+            (int a, float b) => a < b,
+        });
+    }
+
+    public override void OutAGreaterequalExp(AGreaterequalExp node)
+    {
+        values.Add(node, (values[node.GetL()], values[node.GetR()]) switch
+        {
+            // float, int
+            (float a, float b) => a >= b,
+            (int a, int b) => a >= b,
+            //float, int
+            (float a, int b) => a >= b,
+            (int a, float b) => a >= b,
+        });
+    }
+
+    public override void OutAGreaterExp(AGreaterExp node)
+    {
+        values.Add(node, (values[node.GetL()], values[node.GetR()]) switch
+        {
+            // float, int
+            (float a, float b) => a > b,
+            (int a, int b) => a > b,
+            //float, int
+            (float a, int b) => a > b,
+            (int a, float b) => a > b,
+        });
+    }
+
+    public override void OutANotequalExp(ANotequalExp node)
+    {
+        values.Add(node,  (values[node.GetL()], values[node.GetR()]) switch
+        {
+            // float, int, string
+            (float a, float b) => !(Math.Abs(a - b) < 0.05f),
+            (int a, int b) => a != b,
+            (string a, string b) => a != b,
+            //float, int
+            (float a, int b) => !(Math.Abs(a - b) < 0.05f),
+            (int a, float b) => !(Math.Abs(a - b) < 0.05f),
+            //int, string
+            (string a, int b) => a != b.ToString(),
+            (int a, string b) => a.ToString() != b,
+            //float, string
+            (string a, float b) => a != b.ToString(CultureInfo.InvariantCulture),
+            (float a, string b) => a.ToString(CultureInfo.InvariantCulture) != b,
+            //bool
+            (bool a, bool b) => a != b
+        });
+    }
+
+    public override void OutALogicalnotExp(ALogicalnotExp node)
+    {
+        values.Add(node, !(bool)values[node.GetExp()]);
     }
 }

--- a/Compiler/Visitors/ExprEvaluator.cs
+++ b/Compiler/Visitors/ExprEvaluator.cs
@@ -59,7 +59,7 @@ public class ExprEvaluator : DepthFirstAdapter
 
     public override void OutADecimalExp(ADecimalExp node)
     {
-        values.Add(node, float.Parse(node.GetDecimal().ToString()));
+        values.Add(node, float.Parse(node.GetDecimal().ToString(), CultureInfo.InvariantCulture));
     }
 
     public override void OutAMinusExp(AMinusExp node)

--- a/Compiler/Visitors/SymbolTable.cs
+++ b/Compiler/Visitors/SymbolTable.cs
@@ -18,16 +18,20 @@ public class SymbolTable
     private readonly SymbolTable? _parent;
     private readonly Dictionary<string, Node> _idToNode = new();
     public readonly Dictionary<Node, Symbol> _nodeToSymbol = new();
-    
-    public readonly Dictionary<string, AUnitdeclGlobal> IdToUnitDecl = new();
+
+    private readonly Dictionary<string, AUnitdeclGlobal> IdToUnitDecl = new();
     public readonly Dictionary<Node, (SortedList<string, AUnitdeclGlobal>, SortedList<string, AUnitdeclGlobal>)> NodeToUnit = new();
-    
+
     private readonly Dictionary<string, Node> _funcIdToNode = new();
     private readonly Dictionary<Node, List<PType>> _nodeToArgs = new();
     public int Prog = 0;
     public int Loop = 0;
 
-    
+    // ms -> it's exp. Used by codegen to evaluate the unit at compiletime
+    private readonly Dictionary<string, PExp> idToSubUnit = new();
+    public void AddSubUnitExp(ASubunit unit) => _allTables[0].idToSubUnit.Add(unit.GetId().Text.Trim(), unit.GetExp());
+    public PExp GetSubUnitExp(TId key) => _allTables[0].idToSubUnit[key.Text.Trim()];
+
     
     // General methods
     public SymbolTable EnterScope()

--- a/Compiler/Visitors/TypeCheckerDir/exprTypeChecker.cs
+++ b/Compiler/Visitors/TypeCheckerDir/exprTypeChecker.cs
@@ -12,7 +12,7 @@ public class exprTypeChecker : stmtTypeChecker
 
     }
     
-    public override void OutAExpExp(AExpExp node)
+    public override void OutAParenthesisExp(AParenthesisExp node)
     {
         Node exp = node.GetExp();
         if (exp is AIdExp id)

--- a/Compiler/Visitors/TypeCheckerDir/exprTypeChecker.cs
+++ b/Compiler/Visitors/TypeCheckerDir/exprTypeChecker.cs
@@ -643,56 +643,43 @@ public class exprTypeChecker : stmtTypeChecker
         {
             symbolTable.GetNodeFromId(idRight.GetId().ToString().Trim(), out rightExpr);
         }
-        Symbol? leftSymbol = symbolTable.GetSymbol(leftExpr);
-        Symbol? rightSymbol = symbolTable.GetSymbol(rightExpr);
-        switch (leftSymbol)
+        symbolTable.AddNode(node, (symbolTable.GetSymbol(leftExpr), symbolTable.GetSymbol(rightExpr)) switch
         {
-            case Symbol.Int or Symbol.Pin when rightSymbol is Symbol.Int or Symbol.Pin:
-                symbolTable.AddNode(node, Symbol.Int);
-                break;
-            case Symbol.Decimal or Symbol.Int when rightSymbol is Symbol.Decimal or Symbol.Int:
-                symbolTable.AddNode(node, Symbol.Decimal);
-                break;
-            case Symbol.Int or Symbol.Decimal when rightSymbol is Symbol.Decimal:
-                symbolTable.AddNode(node, Symbol.Decimal);
-                break;
-            case Symbol.String when rightSymbol is Symbol.Int or Symbol.String:
-                symbolTable.AddNode(node, Symbol.String);
-                break;
-            case Symbol.Int or Symbol.String when rightSymbol is Symbol.String:
-                symbolTable.AddNode(node, Symbol.String);
-                break;
-            case Symbol.Decimal or Symbol.String when rightSymbol is Symbol.Decimal:
-                symbolTable.AddNode(node, Symbol.String);
-                break;
-            case Symbol.String when rightSymbol is Symbol.String or Symbol.Decimal:
-                symbolTable.AddNode(node, Symbol.String);
-                break;
-            default:
-                // UnitTypes?
-                if (symbolTable.GetUnit(leftExpr, out var unit1) && symbolTable.GetUnit(rightExpr, out var unit2))
-                {
-                    if (symbolTable.CompareUnitTypes(unit1, unit2))
-                    {
-                        symbolTable.AddNodeToUnit(node, unit1);
-                        symbolTable.AddNode(node, Symbol.Ok);
-                    } 
-                    else
-                    {
-                        symbolTable.AddNode(node, Symbol.NotOk);
-                        tempResult += IndentedString("Not the same unitTypes used in expression\n");
-                    }
-                }
-                else
-                {
-                    // not valid input expression
-                    symbolTable.AddNode(node, Symbol.NotOk);
-                    tempResult += IndentedString("Not valid Types used together in expression!\n");
-                }
-                break;
-        }
+            (Symbol.Int, Symbol.Int) => Symbol.Int,
+            (Symbol.Pin, Symbol.Int) => Symbol.Int,
+            (Symbol.Int, Symbol.Pin) => Symbol.Int,
+            (Symbol.Pin, Symbol.Pin) => Symbol.Int,
+            
+            (Symbol.Decimal, Symbol.Decimal) => Symbol.Decimal,
+            (Symbol.Decimal, Symbol.Int) => Symbol.Decimal,
+            (Symbol.Int, Symbol.Decimal) => Symbol.Decimal,
+            
+            (Symbol.String, Symbol.String) => Symbol.String,
+            (Symbol.String, Symbol.Decimal) => Symbol.String,
+            (Symbol.Decimal, Symbol.String) => Symbol.String,
+            (Symbol.String, Symbol.Int) => Symbol.String,
+            (Symbol.Int, Symbol.String) => Symbol.String,
+            _ => SameUnits(node, leftExpr, rightExpr) ? Symbol.Ok : Symbol.NotOk
+        });
         PrintError();
         indent--;
+    }
+
+    private bool SameUnits(Node node, Node leftExpr, Node rightExpr)
+    {
+        if (symbolTable.GetUnit(leftExpr, out var unit1) && symbolTable.GetUnit(rightExpr, out var unit2))
+        {
+            if (symbolTable.CompareUnitTypes(unit1, unit2))
+            {
+                symbolTable.AddNodeToUnit(node, unit1);
+                return true;
+            }
+            tempResult += IndentedString("Not the same unitTypes used in expression\n");
+            return false;
+        }
+        // not valid input expression
+        tempResult += IndentedString("Not valid Types used together in expression!\n");
+        return false;
     }
 
     public override void InAMinusExp(AMinusExp node)
@@ -773,54 +760,21 @@ public class exprTypeChecker : stmtTypeChecker
         }
         Symbol? left = symbolTable.GetSymbol(leftExpr);
         Symbol? right = symbolTable.GetSymbol(rightExpr);
-        switch (left)
+        Symbol output;
+        switch (left, right)
         {
-            case Symbol.Int or Symbol.Pin:
-                if (right is Symbol.Int or Symbol.Pin)
-                {
-                    symbolTable.AddNode(node, Symbol.Int);
-                } else if (right == Symbol.Decimal)
-                {
-                    symbolTable.AddNode(node, Symbol.Decimal);
-                }
-                else
-                { 
-                    symbolTable.AddNode(node, Symbol.NotOk);  
-                    tempResult += IndentedString("Only int and decimals are allowed in remainder expression\n");
-                }
-                break;
-            case Symbol.Decimal:
-                if (right == Symbol.Int || right == Symbol.Decimal)
-                {
-                    symbolTable.AddNode(node, Symbol.Decimal);
-                }
-                else
-                { 
-                    symbolTable.AddNode(node, Symbol.NotOk);  
-                    tempResult += IndentedString("Only decimals are allowed in remainder expression\n");
-                }
+            case (Symbol.Int, Symbol.Int):
+            case (Symbol.Pin, Symbol.Int):
+            case (Symbol.Int, Symbol.Pin):
+                output = Symbol.Int;
                 break;
             default:
-                if (symbolTable.GetUnit(leftExpr, out var unit1) && symbolTable.GetUnit(rightExpr, out var unit2))
-                {
-                    if (symbolTable.CompareUnitTypes(unit1, unit2))
-                    {
-                        symbolTable.AddNodeToUnit(node, unit1);
-                        symbolTable.AddNode(node, Symbol.Ok);
-                    }
-                    else
-                    {
-                        symbolTable.AddNode(node, Symbol.NotOk);
-                        tempResult += IndentedString("Not same unitTypes\n");
-                    } 
-                }
-                else
-                {
-                    symbolTable.AddNode(node, Symbol.NotOk);
-                    tempResult += IndentedString("Remainder expressions is only allowed with ints, decimals and units\n");
-                }
+                output = Symbol.NotOk;
                 break;
         }
+        
+        symbolTable.AddNode(node, output);
+        tempResult += output != Symbol.NotOk ? "" : IndentedString("Only integers allowed in remainder expression\n");
         PrintError();
         indent--;
     }
@@ -1317,49 +1271,35 @@ public class exprTypeChecker : stmtTypeChecker
             symbolTable.GetNodeFromId(idRight.GetId().ToString().Trim(), out rightExpr);
         }
         Symbol? left = symbolTable.GetSymbol(leftExpr);
-        switch (left)
-        {
-            case Symbol.Int:
-                symbolTable.AddNode(Parent, symbolTable.GetSymbol(rightExpr) == Symbol.Int ? Symbol.Bool : Symbol.NotOk);
-                tempResult += symbolTable.GetSymbol(rightExpr) == Symbol.Int ? "" : IndentedString("Types does not match\n");
-                break;
-            case (Symbol.Decimal):
-                symbolTable.AddNode(Parent, symbolTable.GetSymbol(rightExpr) == Symbol.Decimal ? Symbol.Bool : Symbol.NotOk);
-                tempResult += symbolTable.GetSymbol(rightExpr) == Symbol.Decimal ? "" : IndentedString("Types does not match\n");
-                break;
-            case Symbol.Bool:
-                symbolTable.AddNode(Parent, symbolTable.GetSymbol(rightExpr) == Symbol.Bool ? Symbol.Bool : Symbol.NotOk);
-                tempResult += symbolTable.GetSymbol(rightExpr) == Symbol.Bool ? "" : IndentedString("Types does not match\n");
-                break;
-            case Symbol.String:
-                symbolTable.AddNode(Parent, symbolTable.GetSymbol(rightExpr) == Symbol.String ? Symbol.Bool : Symbol.NotOk);
-                tempResult += symbolTable.GetSymbol(rightExpr) == Symbol.String ? "" : IndentedString("Types does not match\n");
-                break;
-            case Symbol.Char:
-                symbolTable.AddNode(Parent, symbolTable.GetSymbol(rightExpr) == Symbol.Char ? Symbol.Bool : Symbol.NotOk);
-                tempResult += symbolTable.GetSymbol(rightExpr) == Symbol.Char ? "" : IndentedString("Types does not match\n");
-                break;
-            case Symbol.Pin:
-                symbolTable.AddNode(Parent, symbolTable.GetSymbol(rightExpr) == Symbol.Pin ? Symbol.Bool : Symbol.NotOk);
-                tempResult += symbolTable.GetSymbol(rightExpr) == Symbol.Pin ? "" : IndentedString("Types does not match\n");
+        Symbol? right = symbolTable.GetSymbol(rightExpr);
+        Symbol output;
+        switch (left, right) {
+            //int, decimal, string, bool, char, pin
+            case (Symbol.Int, Symbol.Int):
+            case (Symbol.Decimal, Symbol.Decimal):
+            case (Symbol.String, Symbol.String):
+            case (Symbol.Bool, Symbol.Bool):
+            case (Symbol.Char, Symbol.Char):
+            case (Symbol.Pin, Symbol.Pin):
+            //decimal
+            case (Symbol.Int, Symbol.Decimal):
+            case (Symbol.Decimal, Symbol.Int):
+            //string
+            case (Symbol.String, Symbol.Int):
+            case (Symbol.Int, Symbol.String):
+            case (Symbol.String, Symbol.Decimal):
+            case (Symbol.Decimal, Symbol.String):
+            //char
+            case (Symbol.Char, Symbol.String):
+            case (Symbol.String, Symbol.Char):
+                output = Symbol.Bool;
                 break;
             default:
-                bool leftContainsUnit = symbolTable.NodeToUnit.ContainsKey(leftExpr);
-                bool rightContainsUnit = symbolTable.NodeToUnit.ContainsKey(rightExpr);
-                if (leftContainsUnit && rightContainsUnit)
-                {
-                    symbolTable.GetUnit(leftExpr, out var unit1);
-                    symbolTable.GetUnit(rightExpr, out var unit2);
-                    symbolTable.AddNode(Parent, symbolTable.CompareUnitTypes(unit1, unit2) ? Symbol.Bool : Symbol.NotOk);
-                    tempResult += symbolTable.CompareUnitTypes(unit1, unit2) ? "" : IndentedString("unitTypes does not match\n");
-                }
-                else
-                {
-                    symbolTable.AddNode(Parent, Symbol.NotOk);
-                    tempResult += IndentedString("types does not match\n");
-                }
+                output = SameUnits(Parent, leftExpr, rightExpr) ? Symbol.Bool : Symbol.NotOk;
                 break;
-        }
+        };
+        symbolTable.AddNode(Parent, output);
+        tempResult += output != Symbol.NotOk ? "" : IndentedString("Types does not match\n");
         PrintError();
         indent--;
     }

--- a/Compiler/Visitors/UnitVisitor.cs
+++ b/Compiler/Visitors/UnitVisitor.cs
@@ -100,6 +100,7 @@ public class UnitVisitor : DepthFirstAdapter
             }
             symbolTable.AddNode(node, Symbol.Decimal);
             symbolTable.AddIdToUnitdecl(node.GetId().ToString().Trim(), (AUnitdeclGlobal) node.Parent());
+            symbolTable.AddSubUnitExp(node);
         }
         else
         {

--- a/Compiler/grammar.sablecc3
+++ b/Compiler/grammar.sablecc3
@@ -252,7 +252,7 @@ Productions
                 | {funccall}        id l_par params? r_par                  {-> New exp.funccall(id, [params.exp])} // <- array and structaccess goes here
                 | p0 {-> p0.exp};
     p0 {-> exp} = {id}              id {-> New exp.id(id)}
-                | {readpin} treadpin l_par exp r_par                        {-> New exp.readpin(exp.exp)}
+                | {readpin}         treadpin l_par exp r_par                {-> New exp.readpin(exp.exp)}
                 | {decimal}         decimal                                 {-> New exp.decimal(decimal)}
                 | {unit}            unitnumber                              {-> unitnumber.exp}
                 | {value}           tvalue                                  {-> New exp.value()}

--- a/Compiler/grammar.sablecc3
+++ b/Compiler/grammar.sablecc3
@@ -260,7 +260,7 @@ Productions
                 | {boolean}         boolean                                 {-> New exp.boolean(boolean.boolean)}
                 | {string}          string                                  {-> New exp.string(string)}
                 | {char}            char                                    {-> New exp.char(char)}
-                | {exp}             l_par exp r_par                         {-> New exp.exp(exp.exp)};
+                | {pexp}             l_par exp r_par                         {-> New exp.parenthesis(exp.exp)};
                 
     //// Miscellaneous    
     boolean {-> boolean} = {true} ttrue {-> New boolean.true()}
@@ -348,7 +348,7 @@ Abstract Syntax Tree
         | {boolean}         boolean
         | {string}          string
         | {char}            char
-        | {exp}             exp;  
+        | {parenthesis}     exp;  
         
     boolean = {true} | {false};
     

--- a/UnitTest/TestWithoutLexerOrParser.cs
+++ b/UnitTest/TestWithoutLexerOrParser.cs
@@ -128,9 +128,9 @@ float Times(float value) {
     return value*1000;
 }
 void setup() {
-    float a = Times(1);
+    float a = 1000;
     if(true) {
-        a = Timems(7.5);
+        a = 7.5;
     }
 }
 String b(int b) {

--- a/UnitTest/TestWithoutLexerOrParser.cs
+++ b/UnitTest/TestWithoutLexerOrParser.cs
@@ -128,9 +128,9 @@ float UTimes(float value) {
     return value*1000;
 }
 void setup() {
-    float a = UTimes(1);
+    float a = 1000;
     if(true) {
-        a = UTimems(7.5);
+        a = 7.5;
     }
 }
 String Fb(int b) {

--- a/UnitTest/TestWithoutLexerOrParser.cs
+++ b/UnitTest/TestWithoutLexerOrParser.cs
@@ -134,9 +134,9 @@ void setup() {
     }
 }
 String Fb(int b) {
-    String c = ""hello "";
+    String c = String(""hello "");
     for(int i = 0; i < b; i++) {
-        c += i+"", "";
+        c += String(i)+String("", "");
     }
     return c;
 }";

--- a/UnitTest/Testcases/CodeGenPrettyPrintTests.testcase
+++ b/UnitTest/Testcases/CodeGenPrettyPrintTests.testcase
@@ -54,7 +54,7 @@ void setup() {
     int p = 5;
     char c = 'e';
     bool d = true;
-    String l = d?"ja":"nej";
+    String l = d?String("ja"):String("nej");
     float e = 1.11;
     String b = String(e, 6);
     FargTest(a, b, c, d, e);

--- a/UnitTest/Testcases/escapedchars.testcase
+++ b/UnitTest/Testcases/escapedchars.testcase
@@ -27,15 +27,15 @@ prog {
 void loop() {
 }
 void setup() {
-    String n = "\n";
+    String n = String("\n");
     char a = '\a';
-    String b = "\b";
-    String f = "\f";
-    String r = "\r";
-    String t = "\t";
-    String v = "\v";
-    String q = "\?";
-    String slash = "\\";
+    String b = String("\b");
+    String f = String("\f");
+    String r = String("\r");
+    String t = String("\t");
+    String v = String("\v");
+    String q = String("\?");
+    String slash = String("\\");
 }
 ////
 true

--- a/UnitTest/Testcases/expr.testcase
+++ b/UnitTest/Testcases/expr.testcase
@@ -83,7 +83,6 @@ func untypedlmao(){
     decimal d = 6.5;
     d = d * cd;
     cd = cd / b;
-    decimal x = d % b; 
 }
 ////
  

--- a/UnitTest/Testcases/exprEvaluator.testcase
+++ b/UnitTest/Testcases/exprEvaluator.testcase
@@ -32,7 +32,7 @@ unit Time {
 void loop() {
 }
 void setup() {
-    float a = 31375000;
+    float a = 3137500;
 }
 float UTimems(float value) {
     return (value*50)*((5*5)*50.2);
@@ -52,7 +52,7 @@ unit Time {
 void loop() {
 }
 void setup() {
-    float a = 612;
+    float a = 160.2;
 }
 float UTimems(float value) {
     return (value+50)+((5+5)+50.2);
@@ -97,7 +97,7 @@ void loop() {
 }
 void setup() {
     float a = 50;
-    float b = 5;
+    float b = 1;
     float c = -1;
 }
 float UTimems(float value) {
@@ -130,6 +130,26 @@ float UTimems(float value) {
     return String(5) == String("5") || String(2.5) == String("2.5") || String("2.5") == String(2.5)?value:value*2;
 }
 //////
+Equals3
+////
+prog {
+    Time a = 50ms;
+}
+
+unit Time {
+    ms => 5 == 5.0 && "5" == 5 ? value : value*2;
+}
+////
+////
+void loop() {
+}
+void setup() {
+    float a = 100;
+}
+float UTimems(float value) {
+    return 5 == 5.0 && String("5") == String(5)?value:value*2;
+}
+//////
 Minus
 ////
 prog {
@@ -144,7 +164,7 @@ unit Time {
 void loop() {
 }
 void setup() {
-    float a = 371;
+    float a = 37.100002;
 }
 float UTimems(float value) {
     return 2.1-((2-1)-1.2-(1-0.5))*value;
@@ -164,7 +184,7 @@ unit Time {
 void loop() {
 }
 void setup() {
-    float a = -240;
+    float a = -25.8;
 }
 float UTimems(float value) {
     return (value/(2/2))/(2/-1.0)+1.2/1+-2;
@@ -236,7 +256,7 @@ unit Time {
 void loop() {
 }
 void setup() {
-    float a = 50;
+    float a = 250;
 }
 float UTimems(float value) {
     return String("a") != String("b") && String("2") != String(1) && 1.2 != 1 && 1 != 1.0?value:value*5;
@@ -260,4 +280,62 @@ void setup() {
 }
 float UTimems(float value) {
     return value+5 % 3;
+}
+//////
+LessGreater
+////
+prog {
+    Time a = 50ms;
+    Time b = 1s;
+    Time c = 3h;
+    Time d = 5d;
+}
+
+unit Time {
+    ms => 7 < 5 || 7 <= 5 || 5 >= 7 || 3 > 6 ? value : value+2;
+    s => 7.0 < 5.0 || 7.0 <= 5.0 || 5.0 >= 7.0 || 3.0 > 6.0 ? value : value+2;
+    h => 7.0 < 5 || 7.0 <= 5 || 5.0 >= 7 || 3.0 > 6 ? value : value+2;
+    d => 7 < 5.0 || 7 <= 5.0 || 5 >= 7.0 || 3 > 6.0 ? value : value+2;
+}
+////
+////
+void loop() {
+}
+void setup() {
+    float a = 52;
+    float b = 3;
+    float c = 5;
+    float d = 7;
+}
+float UTimems(float value) {
+    return 7 < 5 || 7 <= 5 || 5 >= 7 || 3 > 6?value:value+2;
+}
+float UTimes(float value) {
+    return 7.0 < 5.0 || 7.0 <= 5.0 || 5.0 >= 7.0 || 3.0 > 6.0?value:value+2;
+}
+float UTimeh(float value) {
+    return 7.0 < 5 || 7.0 <= 5 || 5.0 >= 7 || 3.0 > 6?value:value+2;
+}
+float UTimed(float value) {
+    return 7 < 5.0 || 7 <= 5.0 || 5 >= 7.0 || 3 > 6.0?value:value+2;
+}
+//////
+LogicalNot
+////
+prog {
+    Time a = 50ms;
+}
+
+unit Time {
+    ms => !true || !false ? value : value*2;
+}
+////
+////
+void loop() {
+}
+void setup() {
+    float a = 50;
+}
+float UTimems(float value) {
+    return !true || !false?value:value*2;
 }

--- a/UnitTest/Testcases/exprEvaluator.testcase
+++ b/UnitTest/Testcases/exprEvaluator.testcase
@@ -1,0 +1,263 @@
+﻿Parenthesis
+////
+prog {
+    Time a = 50ms;
+}
+
+unit Time {
+    ms => (value);
+}
+////
+////
+void loop() {
+}
+void setup() {
+    float a = 50;
+}
+float UTimems(float value) {
+    return (value);
+}
+//////
+Multiply
+////
+prog {
+    Time a = 50ms;
+}
+
+unit Time {
+    ms => (value * 50) * ((5*5) * 50.2);
+}
+////
+////
+void loop() {
+}
+void setup() {
+    float a = 31375000;
+}
+float UTimems(float value) {
+    return (value*50)*((5*5)*50.2);
+}
+//////
+Plus
+////
+prog {
+    Time a = 50ms;
+}
+
+unit Time {
+    ms => (value + 50) + ((5+5) + 50.2);
+}
+////
+////
+void loop() {
+}
+void setup() {
+    float a = 612;
+}
+float UTimems(float value) {
+    return (value+50)+((5+5)+50.2);
+}
+//////
+Plus3
+////
+prog {
+    Time a = 50ms;
+}
+
+unit Time {
+    ms => 2+("hej"+1)+("alo"+1.2)+(1.1+"aye") == "hej"?50*value:5*value;
+}
+////
+////
+void loop() {
+}
+void setup() {
+    float a = 250;
+}
+float UTimems(float value) {
+    return String(2)+(String("hej")+String(1))+(String("alo")+String(1.2))+(String(1.1)+String("aye")) == String("hej")?50*value:5*value;
+}
+//////
+Equals
+////
+prog {
+    Time a = 50ms;
+    Time b = 1s;
+    Time c = 1h;
+}
+
+unit Time {
+    ms => 5 == 5 || true ? value : value*5;
+    s => 2.2 == 2.2 && 2.0 == 2 || 2 == 2.0 || "hey" == 5 && "5" == 5 && "2.2" == 2.2 && 2.2 == "2.2" ? value : value*5;
+    h => true == false ? value : value-2;
+}
+////
+////
+void loop() {
+}
+void setup() {
+    float a = 50;
+    float b = 5;
+    float c = -1;
+}
+float UTimems(float value) {
+    return 5 == 5 || true?value:value*5;
+}
+float UTimes(float value) {
+    return 2.2 == 2.2 && 2.0 == 2 || 2 == 2.0 || String("hey") == String(5) && String("5") == String(5) && String("2.2") == String(2.2) && String(2.2) == String("2.2")?value:value*5;
+}
+float UTimeh(float value) {
+    return true == false?value:value-2;
+}
+//////
+Equals2
+////
+prog {
+    Time a = 50ms;
+}
+
+unit Time {
+    ms => 5 == "5" || 2.5 == "2.5" || "2.5" == 2.5 ? value : value*2;
+}
+////
+////
+void loop() {
+}
+void setup() {
+    float a = 100;
+}
+float UTimems(float value) {
+    return String(5) == String("5") || String(2.5) == String("2.5") || String("2.5") == String(2.5)?value:value*2;
+}
+//////
+Minus
+////
+prog {
+    Time a = 50ms;
+}
+
+unit Time {
+    ms => 2.1 - ((2 - 1) - 1.2 - (1 - 0.5)) * value;
+}
+////
+////
+void loop() {
+}
+void setup() {
+    float a = 371;
+}
+float UTimems(float value) {
+    return 2.1-((2-1)-1.2-(1-0.5))*value;
+}
+//////
+Divide
+////
+prog {
+    Time a = 50ms;
+}
+
+unit Time {
+    ms => (value / (2 / 2)) / (2 / -1.0) + 1.2/1 + -2;
+}
+////
+////
+void loop() {
+}
+void setup() {
+    float a = -240;
+}
+float UTimems(float value) {
+    return (value/(2/2))/(2/-1.0)+1.2/1+-2;
+}
+//////
+NotEquals
+////
+prog {
+    Time a = 50ms;
+    Time b = 1s;
+    Time c = 1h;
+}
+
+unit Time {
+    ms => 5 != 5 && true ? value : value*5;
+    s => 2.2 != 2.2 && 2.0 != 2 && 2 != 2.0 && "hey" != 5 && "5" != 5 && "2.2" != 2.2 && 2.2 != "2.2" ? value : value*5;
+    h => true != false ? value : value-2;
+}
+////
+////
+void loop() {
+}
+void setup() {
+    float a = 250;
+    float b = 5;
+    float c = 1;
+}
+float UTimems(float value) {
+    return 5 != 5 && true?value:value*5;
+}
+float UTimes(float value) {
+    return 2.2 != 2.2 && 2.0 != 2 && 2 != 2.0 && String("hey") != String(5) && String("5") != String(5) && String("2.2") != String(2.2) && String(2.2) != String("2.2")?value:value*5;
+}
+float UTimeh(float value) {
+    return true != false?value:value-2;
+}
+//////
+NotEquals2
+////
+prog {
+    Time a = 50ms;
+}
+
+unit Time {
+    ms => 5 != "5" && 2.5 != "2.5" && "2.5" != 2.5 ? value : value*2;
+}
+////
+////
+void loop() {
+}
+void setup() {
+    float a = 50;
+}
+float UTimems(float value) {
+    return String(5) != String("5") && String(2.5) != String("2.5") && String("2.5") != String(2.5)?value:value*2;
+}
+//////
+NotEquals3
+////
+prog {
+    Time a = 50ms;
+}
+
+unit Time {
+    ms => "a" != "b" && "2" != 1 && 1.2 != 1 && 1 != 1.0 ? value : value*5;
+}
+////
+////
+void loop() {
+}
+void setup() {
+    float a = 50;
+}
+float UTimems(float value) {
+    return String("a") != String("b") && String("2") != String(1) && 1.2 != 1 && 1 != 1.0?value:value*5;
+}
+//////
+Remainder
+////
+prog {
+    Time a = 50ms;
+}
+
+unit Time {
+    ms => value + 5 % 3;
+}
+////
+////
+void loop() {
+}
+void setup() {
+    float a = 52;
+}
+float UTimems(float value) {
+    return value+5 % 3;
+}

--- a/UnitTest/Testcases/func.testcase
+++ b/UnitTest/Testcases/func.testcase
@@ -65,7 +65,7 @@ void loop() {
     int f = 0;
 }
 String FImplicitTypedFunc() {
-    String i = "0";
+    String i = String("0");
     return i;
 }
 char Ffunction3(char a, char b, char c) {

--- a/UnitTest/Testcases/unituse.testcase
+++ b/UnitTest/Testcases/unituse.testcase
@@ -24,11 +24,11 @@ float UTimes(float value) {
     return value*1000;
 }
 float FUnitFunc() {
-    float a = 1/UTimems(50);
+    float a = 1/50;
     return a;
 }
 void setup() {
-    float a = 1/UTimems(50);
+    float a = 1/50;
 }
 void loop() {
     float c = 200.0;
@@ -68,8 +68,8 @@ float UTimes(float value) {
 }
 void setup() {
     float e = 3.7;
-    float a = 1/UTimems(50.3)+1/UTimes(5);
-    float b = 1/UTimems(50)-1/UTimes(5);
+    float a = 1/50.3+1/5000;
+    float b = 1/50-1/5000;
 }
 ////
 true

--- a/UnitTest/Testcases/unituse.testcase
+++ b/UnitTest/Testcases/unituse.testcase
@@ -24,11 +24,11 @@ float Times(float value) {
     return value*1000;
 }
 float UnitFunc() {
-    float a = 1/Timems(50);
+    float a = 1/50;
     return a;
 }
 void setup() {
-    float a = 1/Timems(50);
+    float a = 1/50;
 }
 void loop() {
     float c = 200.0;
@@ -68,8 +68,8 @@ float Times(float value) {
 }
 void setup() {
     float e = 3.7;
-    float a = 1/Timems(50.3)+1/Times(5);
-    float b = 1/Timems(50)-1/Times(5);
+    float a = 1/50.3+1/5000;
+    float b = 1/50-1/5000;
 }
 ////
 true


### PR DESCRIPTION
closes #64 

- [x] Support for decimals, numbers, (), *, /, -, +, --, ++, %, cast
- [x] Support for booleans, &, |, ternary ?, not elevating numbers to decimals immediately(some new value table)
- [x] If the subunit uses either variables, other units or functions use the codegen unitfunction, however else avoid producing the unused unitfunction. This will require marking subunits as complex in typechecking, codegen only complex units and codegen evaluating simple units.